### PR TITLE
fix: fixed global storage usage in windows system

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -20,7 +20,7 @@ export async function dataDirectory(context: ExtensionContext, ...relatives: str
         await workspace.fs.createDirectory(dir);
     }
 
-    return join(dir.path, ...relatives);
+    return join(dir.fsPath, ...relatives);
 }
 
 export async function converterBinary(context: ExtensionContext): Promise<string> {


### PR DESCRIPTION
it was not possible to download libwebp binaries in windows system because of the way the global storage Uri was being used. it was starting with `/` instead of `C:/` for example. i already tested this implementation in windows and in WSL and it is working on both.